### PR TITLE
Correct how the state gets changed

### DIFF
--- a/Assets/Scripts/NextLevelHole.cs
+++ b/Assets/Scripts/NextLevelHole.cs
@@ -4,13 +4,9 @@ using UnityEngine.SceneManagement;
 public class NextLevelHole : MonoBehaviour {
 
 	void OnTriggerEnter2D(Collider2D col) {
-
 		if(col.CompareTag("Player")) {
-
 			// change string value to name of scene to be loaded when triggered
-			SceneManager.LoadScene("betweenLevels");
-
-		}
-		
-		}
+			GameStateManager.Instance.SetGameState(GameState.BETWEEN_LEVEL);
+		};
+	}
 }


### PR DESCRIPTION
This fixes how the `NextLevelHole` is updating the scene so that it's the state manager doing the transitional stuff in order to keep scene changes consistent across all of the codebase. (this also makes it so that the in-game stuff doesn't keep processing when it isn't on that scene)