### PR TITLE
Feature/level number

### DIFF
--- a/Assets/Scripts/GameStateManager.cs
+++ b/Assets/Scripts/GameStateManager.cs
@@ -96,7 +96,7 @@ public class GameStateManager {
 	//=======================================================================\\
 	// Generic game-data
 
-	private int _level = 0;
+	private int _level = 1;
 	public int level {
 		get {
 			return this._level;


### PR DESCRIPTION
Adds a level number that gets incremented when the player goes to the between Levels scene, and then resets when going to the main menu. This value is initialized to `1` so that the value can be used in mathematical calculations without having to check if it is 0 before using it.